### PR TITLE
Setup CI for the gemini repo

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,64 @@
+on: [push, pull_request]
+
+name: Continuous integration
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add clippy
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,22 @@
 [package]
 name = "gemini"
-version = "0.1.0"
+version = "0.0.1"
 authors = ["Michael Gattozzi <mgattozzi@gmail.com>"]
 edition = "2018"
-decription = "An attribute proc macro that lets a user choose a sync or async API with no overhead maintenance burden."
+description = "An attribute proc macro that lets a user choose a sync or async API with no overhead maintenance burden."
+readme = "README.md"
+homepage = "https://github.com/mgattozzi/gemini"
+repository = "https://github.com/mgattozzi/gemini"
+license = "MIT OR Apache-2.0"
+keywords = [ "rust", "async", "sync", "proc-macro", "proc-macro-attributes" ]
+categories = [ "asynchronous", "concurrency", "development-tools" ]
 
 [lib]
 proc-macro = true
 
 [dependencies]
-syn = { version = "*", features=["full", "extra-traits", "clone-impls", "visit-mut"] }
-quote = "*"
+syn = { version = "1.0", features = [ "full", "extra-traits", "clone-impls", "visit-mut" ] }
+quote = "1.0"
 
 [features]
 default = []

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # `gemini`
------
 An attribute proc macro that lets a user choose a sync or async API with no
 overhead maintenance burden.
 
@@ -51,7 +50,7 @@ to:
 use gemini::gemini;
 
 #[cfg(not(feature = "sync"))]
-pub async fn basic(item: Vec<String>) -> Result<(), String> {
+pub async fn basic() -> Result<(), String> {
     func().await?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ use syn::{
 #[proc_macro_attribute]
 pub fn gemini(_attr: TokenStream, tokens: TokenStream) -> TokenStream {
   let input = parse_macro_input!(tokens as ItemFn);
-  if let None = &input.sig.asyncness {
+  if input.sig.asyncness.is_none() {
     panic!("The gemini macro requires that you put the attribute on an async function")
   }
   let mut sync = input.clone();


### PR DESCRIPTION
Going forward we'll need actual CI to be able to make sure no mistakes make it in to master and that we always have a green build. This sets up a minimal CI pipeline for the repo.